### PR TITLE
feat: add link to add to Google Calendar and Outlook Calendar

### DIFF
--- a/app/Contracts/ScheduleCommand.php
+++ b/app/Contracts/ScheduleCommand.php
@@ -15,8 +15,9 @@ abstract class ScheduleCommand extends Command
         $includePast = $this->option('include-past') ?: false;
         $feed = Reader::read(Http::get($this->getFeedUrl())->body());
         $feedName = $this->getFeedName();
+        $supportsTerminalHyperlinks = supports_terminal_hyperlinks();
 
-        render(view('feed', compact('includePast', 'feed', 'feedName')));
+        render(view('feed', compact('includePast', 'feed', 'feedName', 'supportsTerminalHyperlinks')));
     }
 
     public function getDescription(): string

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Env;
 use Sabre\VObject\Component\VEvent;
+use Spatie\CalendarLinks\Link;
 
 if (! function_exists('supports_terminal_hyperlinks')) {
     function supports_terminal_hyperlinks(): bool
@@ -40,13 +41,27 @@ if (! function_exists('supports_terminal_hyperlinks')) {
 if (! function_exists('google_calendar_event')) {
     function google_calendar_event(VEvent $event): string
     {
-        return sprintf(
-            'https://calendar.google.com/calendar/r/eventedit?text=%s&dates=%s/%s&details=%s&location=%s',
-            urlencode(str($event->SUMMARY->getValue())->before(',')), // @phpstan-ignore-line
-            urlencode($event->DTSTART->getValue()), // @phpstan-ignore-line
-            urlencode($event->DTEND->getValue()), // @phpstan-ignore-line
-            urlencode(str($event->SUMMARY->getValue())->before(',').PHP_EOL.PHP_EOL.$event->URL->getValue()), // @phpstan-ignore-line
-            urlencode($event->LOCATION->getValue()), // @phpstan-ignore-line
-        );
+        return Link::create(
+            str($event->SUMMARY->getValue())->before(','), // @phpstan-ignore-line
+            $event->DTSTART->getDateTime(), // @phpstan-ignore-line
+            $event->DTEND->getDateTime(), // @phpstan-ignore-line
+        )
+            ->description(str($event->SUMMARY->getValue())->before(',').PHP_EOL.PHP_EOL.$event->URL->getValue()) // @phpstan-ignore-line
+            ->address($event->LOCATION->getValue()) // @phpstan-ignore-line
+            ->google();
+    }
+}
+
+if (! function_exists('outlook_calendar_event')) {
+    function outlook_calendar_event(VEvent $event): string
+    {
+        return Link::create(
+            str($event->SUMMARY->getValue())->before(','), // @phpstan-ignore-line
+            $event->DTSTART->getDateTime(), // @phpstan-ignore-line
+            $event->DTEND->getDateTime(), // @phpstan-ignore-line
+        )
+            ->description(str($event->SUMMARY->getValue())->before(',').PHP_EOL.PHP_EOL.$event->URL->getValue()) // @phpstan-ignore-line
+            ->address($event->LOCATION->getValue()) // @phpstan-ignore-line
+            ->webOutlook();
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,17 @@
+<?php
+
+use Sabre\VObject\Component\VEvent;
+
+if (! function_exists('google_calendar_event')) {
+    function google_calendar_event(VEvent $event)
+    {
+        return sprintf(
+            'https://calendar.google.com/calendar/r/eventedit?text=%s&dates=%s/%s&details=%s&location=%s',
+            urlencode(str($event->SUMMARY->getValue())->before(',')),
+            urlencode($event->DTSTART->getValue()),
+            urlencode($event->DTEND->getValue()),
+            urlencode(str($event->SUMMARY->getValue())->before(',').PHP_EOL.PHP_EOL.$event->URL->getValue()),
+            urlencode($event->LOCATION->getValue()),
+        );
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -3,15 +3,15 @@
 use Sabre\VObject\Component\VEvent;
 
 if (! function_exists('google_calendar_event')) {
-    function google_calendar_event(VEvent $event)
+    function google_calendar_event(VEvent $event): string
     {
         return sprintf(
             'https://calendar.google.com/calendar/r/eventedit?text=%s&dates=%s/%s&details=%s&location=%s',
-            urlencode(str($event->SUMMARY->getValue())->before(',')),
-            urlencode($event->DTSTART->getValue()),
-            urlencode($event->DTEND->getValue()),
-            urlencode(str($event->SUMMARY->getValue())->before(',').PHP_EOL.PHP_EOL.$event->URL->getValue()),
-            urlencode($event->LOCATION->getValue()),
+            urlencode(str($event->SUMMARY->getValue())->before(',')), // @phpstan-ignore-line
+            urlencode($event->DTSTART->getValue()), // @phpstan-ignore-line
+            urlencode($event->DTEND->getValue()), // @phpstan-ignore-line
+            urlencode(str($event->SUMMARY->getValue())->before(',').PHP_EOL.PHP_EOL.$event->URL->getValue()), // @phpstan-ignore-line
+            urlencode($event->LOCATION->getValue()), // @phpstan-ignore-line
         );
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,6 +1,41 @@
 <?php
 
+use Illuminate\Support\Env;
 use Sabre\VObject\Component\VEvent;
+
+if (! function_exists('supports_terminal_hyperlinks')) {
+    function supports_terminal_hyperlinks(): bool
+    {
+        // Hyperlinks forced through environment
+        if (Env::get('FORCE_HYPERLINK')) {
+            return true;
+        }
+
+        // DomTerm
+        if (Env::get('DOMTERM')) {
+            return true;
+        }
+
+        // Terminal Programs
+        if (($program = Env::get('TERM_PROGRAM')) &&
+            in_array($program, ['Hyper', 'iTerm.app', 'terminology', 'WezTerm'], true)
+        ) {
+            return true;
+        }
+
+        // Kitty
+        if (($program = Env::get('TERM')) && $program === 'xterm-kitty') {
+            return true;
+        }
+
+        // Windows Terminal or Konsole
+        if (Env::get('WT_SESSION') || Env::get('KONSOLE_VERSION')) {
+            return true;
+        }
+
+        return false;
+    }
+}
 
 if (! function_exists('google_calendar_event')) {
     function google_calendar_event(VEvent $event): string

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
     "autoload": {
         "psr-4": {
             "App\\": "app/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "scripts": {
         "test:types": "phpstan analyse --ansi --memory-limit=-1",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "laravel-zero/framework": "^9.0",
         "nunomaduro/larastan": "^2.1",
         "nunomaduro/termwind": "^1.6.2",
-        "sabre/vobject": "^4.4"
+        "sabre/vobject": "^4.4",
+        "spatie/calendar-links": "^1.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "illuminate/view": "^9.5",
         "laravel-zero/framework": "^9.0",
         "nunomaduro/larastan": "^2.1",
-        "nunomaduro/termwind": "^1.3",
+        "nunomaduro/termwind": "^1.6.2",
         "sabre/vobject": "^4.4"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "799e3750e7529f5fa1387444e272f7b4",
+    "content-hash": "ad18ebec6f239626532d3a1a6a8cf8d3",
     "packages": [],
     "packages-dev": [
         {
@@ -3916,6 +3916,65 @@
                 "source": "https://github.com/fruux/sabre-xml"
             },
             "time": "2021-11-04T06:37:27+00:00"
+        },
+        {
+            "name": "spatie/calendar-links",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/calendar-links.git",
+                "reference": "59becfff704eaaaf1e6d54462bc384358059efb7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/calendar-links/zipball/59becfff704eaaaf1e6d54462bc384358059efb7",
+                "reference": "59becfff704eaaaf1e6d54462bc384358059efb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpunit/phpunit": "^9.5",
+                "spatie/phpunit-snapshot-assertions": "^4.0",
+                "vimeo/psalm": "^4.20"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\CalendarLinks\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Generate add to calendar links for Google, iCal and other calendar systems",
+            "homepage": "https://github.com/spatie/calendar-links",
+            "keywords": [
+                "calendar-links",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/calendar-links/issues",
+                "source": "https://github.com/spatie/calendar-links/tree/1.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2022-02-13T21:23:48+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "384c5ab33b98f7cbb82ef929e02f9430",
+    "content-hash": "799e3750e7529f5fa1387444e272f7b4",
     "packages": [],
     "packages-dev": [
         {
@@ -2815,16 +2815,16 @@
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "778f0802826c1ed841b7778da2796aa836aec000"
+                "reference": "ef6a5a86c5fad3c7c9bffdc012dc006a0e042548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/778f0802826c1ed841b7778da2796aa836aec000",
-                "reference": "778f0802826c1ed841b7778da2796aa836aec000",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/ef6a5a86c5fad3c7c9bffdc012dc006a0e042548",
+                "reference": "ef6a5a86c5fad3c7c9bffdc012dc006a0e042548",
                 "shasum": ""
             },
             "require": {
@@ -2881,7 +2881,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v1.6.1"
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.6.2"
             },
             "funding": [
                 {
@@ -2897,7 +2897,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-03-17T18:45:55+00:00"
+            "time": "2022-03-18T13:07:34+00:00"
         },
         {
             "name": "phpmyadmin/sql-parser",

--- a/resources/views/feed.blade.php
+++ b/resources/views/feed.blade.php
@@ -36,11 +36,15 @@
                             <span>{{ $event->LOCATION->getValue() }}</span>
                         </td>
                         <td>
-                            <span>{{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->format('D jS M Y') }} ({{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->longRelativeToNowDiffForHumans() }})</span>
+                            <span>{{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->format('H:i D jS M Y') }} ({{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->shortRelativeToNowDiffForHumans() }})</span>
                         </td>
                         @if ($supportsTerminalHyperlinks)
                             <td>
-                                <a href="{{ google_calendar_event($event) }}">Google</a>
+                                <span>
+                                    <a href="{{ google_calendar_event($event) }}">Google</a>
+                                    <span> </span>
+                                    <a href="{{ outlook_calendar_event($event) }}">Outlook</a>
+                                </span>
                             </td>
                         @endif
                     </tr>

--- a/resources/views/feed.blade.php
+++ b/resources/views/feed.blade.php
@@ -2,6 +2,7 @@
     /** @var Sabre\VObject\Component\VCalendar $feed */
     /** @var bool $includePast */
     /** @var string $feedName */
+    /** @var bool $supportsTerminalHyperlinks */
 @endphp
 
 <div class="ml-2 my-1">
@@ -16,7 +17,9 @@
             <th>Teams</th>
             <th>Location</th>
             <th>Date</th>
-            <th>Add to Calendar</th>
+            @if ($supportsTerminalHyperlinks)
+                <th>Add to Calendar</th>
+            @endif
         </tr>
         </thead>
         @if (isset($feed->VEVENT) && ! empty($feed->VEVENT))
@@ -35,15 +38,21 @@
                         <td>
                             <span>{{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->format('D jS M Y') }} ({{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->longRelativeToNowDiffForHumans() }})</span>
                         </td>
-                        <td>
-                            <a href="{{ google_calendar_event($event) }}">Google</a>
-                        </td>
+                        @if ($supportsTerminalHyperlinks)
+                            <td>
+                                <a href="{{ google_calendar_event($event) }}">Google</a>
+                            </td>
+                        @endif
                     </tr>
                 @endif
             @endforeach
         @else
             <tr>
-                <td colspan="4">No events were found for the specified schedule.</td>
+                @if ($supportsTerminalHyperlinks)
+                    <td colspan="5">No events were found for the specified schedule.</td>
+                @else
+                    <td colspan="4">No events were found for the specified schedule.</td>
+                @endif
             </tr>
         @endif
     </table>

--- a/resources/views/feed.blade.php
+++ b/resources/views/feed.blade.php
@@ -16,6 +16,7 @@
             <th>Teams</th>
             <th>Location</th>
             <th>Date</th>
+            <th>Add to Calendar</th>
         </tr>
         </thead>
         @if (isset($feed->VEVENT) && ! empty($feed->VEVENT))
@@ -33,6 +34,9 @@
                         </td>
                         <td>
                             <span>{{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->format('D jS M Y') }} ({{ Illuminate\Support\Carbon::parse($event->DTSTART->getValue())->longRelativeToNowDiffForHumans() }})</span>
+                        </td>
+                        <td>
+                            <a href="{{ google_calendar_event($event) }}">Google</a>
                         </td>
                     </tr>
                 @endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It might be worth checking whether the Terminal can support this before rendering, not sure if that's possible in Symfony / Laravel Zero though. 🤔

There is an issue with Termwind and `a` tags nested within tables ([see this line](https://github.com/nunomaduro/termwind/blob/master/src/Html/TableRenderer.php#L170)). This is also the reason the link to the ID doesn't work, but that's less of an issue at the moment. 👍🏻

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/rugby-schedule/blob/main/.github/CONTRIBUTING.md)** document.
